### PR TITLE
feat: client chat interface & AI integration

### DIFF
--- a/apps/data-service/package.json
+++ b/apps/data-service/package.json
@@ -17,6 +17,7 @@
 		"wrangler": "^4.73.0"
 	},
 	"dependencies": {
+		"@anthropic-ai/sdk": "^0.80.0",
 		"@hono/zod-validator": "^0.7.6",
 		"@repo/data-ops": "workspace:*",
 		"hono": "^4.12.8"

--- a/apps/data-service/service-bindings.d.ts
+++ b/apps/data-service/service-bindings.d.ts
@@ -6,4 +6,6 @@ interface ExampleQueueMessage {
 	messageData;
 }
 
-interface Env extends Cloudflare.Env {}
+interface Env extends Cloudflare.Env {
+	ANTHROPIC_API_KEY: string;
+}

--- a/apps/data-service/src/hono/app.ts
+++ b/apps/data-service/src/hono/app.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import chat from "./handlers/chat-handlers";
 import clients from "./handlers/client-handlers";
 import health from "./handlers/health-handlers";
 import projects from "./handlers/project-handlers";
@@ -15,3 +16,4 @@ App.use("*", createCorsMiddleware());
 App.route("/health", health);
 App.route("/clients", clients);
 App.route("/projects", projects);
+App.route("/chat", chat);

--- a/apps/data-service/src/hono/handlers/chat-handlers.test.ts
+++ b/apps/data-service/src/hono/handlers/chat-handlers.test.ts
@@ -1,0 +1,206 @@
+import { initDatabase } from "@repo/data-ops/database/setup";
+import { createMessage, deleteProject, type Message, type Project } from "@repo/data-ops/project";
+import { App } from "../app";
+
+vi.mock("@anthropic-ai/sdk", () => {
+	return {
+		default: class MockAnthropic {
+			messages = {
+				create: vi.fn().mockResolvedValue({
+					content: [
+						{ type: "text", text: "Thanks for sharing! What problem does your project solve?" },
+					],
+				}),
+			};
+		},
+	};
+});
+
+const TEST_ENV = {
+	API_TOKEN: "test-token",
+	ANTHROPIC_API_KEY: "test-anthropic-key",
+	DATABASE_HOST: process.env.DATABASE_HOST!,
+	DATABASE_USERNAME: process.env.DATABASE_USERNAME!,
+	DATABASE_PASSWORD: process.env.DATABASE_PASSWORD!,
+	CLOUDFLARE_ENV: "dev",
+	ALLOWED_ORIGINS: "",
+} as unknown as Env;
+
+const createdIds: string[] = [];
+
+beforeAll(() => {
+	initDatabase({
+		host: process.env.DATABASE_HOST!,
+		username: process.env.DATABASE_USERNAME!,
+		password: process.env.DATABASE_PASSWORD!,
+	});
+});
+
+afterAll(async () => {
+	for (const id of createdIds) {
+		await deleteProject(id);
+	}
+});
+
+async function createTestProject(): Promise<Project> {
+	const res = await App.request(
+		"/projects",
+		{
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer test-token",
+			},
+			body: JSON.stringify({ name: "__chat_test_project__" }),
+		},
+		TEST_ENV,
+	);
+	const project = (await res.json()) as Project;
+	createdIds.push(project.id);
+	return project;
+}
+
+describe("GET /chat/:slug/messages", () => {
+	it("returns empty message array for project with no messages", async () => {
+		const project = await createTestProject();
+
+		const res = await App.request(`/chat/${project.slug}/messages`, { method: "GET" }, TEST_ENV);
+
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Message[];
+		expect(body).toEqual([]);
+	});
+
+	it("returns messages in chronological order", async () => {
+		const project = await createTestProject();
+		await createMessage({ projectId: project.id, role: "user", content: "Hello" });
+		await createMessage({ projectId: project.id, role: "assistant", content: "Hi there" });
+
+		const res = await App.request(`/chat/${project.slug}/messages`, { method: "GET" }, TEST_ENV);
+
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Message[];
+		expect(body).toHaveLength(2);
+		expect(body[0]?.role).toBe("user");
+		expect(body[0]?.content).toBe("Hello");
+		expect(body[1]?.role).toBe("assistant");
+		expect(body[1]?.content).toBe("Hi there");
+	});
+
+	it("returns 404 for unknown slug", async () => {
+		const res = await App.request(
+			"/chat/nonexistent-slug-00000000/messages",
+			{ method: "GET" },
+			TEST_ENV,
+		);
+
+		expect(res.status).toBe(404);
+		const body = (await res.json()) as { code: string };
+		expect(body.code).toBe("NOT_FOUND");
+	});
+});
+
+describe("POST /chat/:slug/messages", () => {
+	it("rejects empty content with 400", async () => {
+		const project = await createTestProject();
+
+		const res = await App.request(
+			`/chat/${project.slug}/messages`,
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ content: "" }),
+			},
+			TEST_ENV,
+		);
+
+		expect(res.status).toBe(400);
+	});
+
+	it("returns 404 for unknown slug", async () => {
+		const res = await App.request(
+			"/chat/nonexistent-slug-00000000/messages",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ content: "Hello" }),
+			},
+			TEST_ENV,
+		);
+
+		expect(res.status).toBe(404);
+		const body = (await res.json()) as { code: string };
+		expect(body.code).toBe("NOT_FOUND");
+	});
+
+	it("persists user message, calls Claude, persists assistant message, returns both", async () => {
+		const project = await createTestProject();
+
+		const res = await App.request(
+			`/chat/${project.slug}/messages`,
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ content: "I want to build a task manager" }),
+			},
+			TEST_ENV,
+		);
+
+		expect(res.status).toBe(201);
+		const body = (await res.json()) as { userMessage: Message; assistantMessage: Message };
+		expect(body.userMessage.role).toBe("user");
+		expect(body.userMessage.content).toBe("I want to build a task manager");
+		expect(body.assistantMessage.role).toBe("assistant");
+		expect(body.assistantMessage.content).toContain("What problem");
+
+		// Verify messages persisted in DB
+		const historyRes = await App.request(
+			`/chat/${project.slug}/messages`,
+			{ method: "GET" },
+			TEST_ENV,
+		);
+		const history = (await historyRes.json()) as Message[];
+		expect(history).toHaveLength(2);
+		expect(history[0]?.role).toBe("user");
+		expect(history[1]?.role).toBe("assistant");
+	});
+
+	it("sends full conversation history to Claude for resume", async () => {
+		const project = await createTestProject();
+
+		// First exchange
+		await App.request(
+			`/chat/${project.slug}/messages`,
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ content: "I want to build a CRM" }),
+			},
+			TEST_ENV,
+		);
+
+		// Second exchange — history should include first pair
+		const res = await App.request(
+			`/chat/${project.slug}/messages`,
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ content: "For small businesses" }),
+			},
+			TEST_ENV,
+		);
+
+		expect(res.status).toBe(201);
+
+		// Verify all 4 messages in DB
+		const historyRes = await App.request(
+			`/chat/${project.slug}/messages`,
+			{ method: "GET" },
+			TEST_ENV,
+		);
+		const history = (await historyRes.json()) as Message[];
+		expect(history).toHaveLength(4);
+		expect(history[0]?.content).toBe("I want to build a CRM");
+		expect(history[2]?.content).toBe("For small businesses");
+	});
+});

--- a/apps/data-service/src/hono/handlers/chat-handlers.ts
+++ b/apps/data-service/src/hono/handlers/chat-handlers.ts
@@ -1,0 +1,29 @@
+import { zValidator } from "@hono/zod-validator";
+import { MessageCreateRequestSchema, SlugParamSchema } from "@repo/data-ops/project";
+import { Hono } from "hono";
+import * as chatService from "../services/chat-service";
+import { resultToResponse } from "../utils/response";
+
+const chat = new Hono<{ Bindings: Env }>();
+
+chat.get("/:slug/messages", zValidator("param", SlugParamSchema), async (c) => {
+	const { slug } = c.req.valid("param");
+	return resultToResponse(c, await chatService.getMessageHistory(slug));
+});
+
+chat.post(
+	"/:slug/messages",
+	zValidator("param", SlugParamSchema),
+	zValidator("json", MessageCreateRequestSchema),
+	async (c) => {
+		const { slug } = c.req.valid("param");
+		const data = c.req.valid("json");
+		return resultToResponse(
+			c,
+			await chatService.sendMessage(slug, data, c.env.ANTHROPIC_API_KEY),
+			201,
+		);
+	},
+);
+
+export default chat;

--- a/apps/data-service/src/hono/handlers/client-handlers.ts
+++ b/apps/data-service/src/hono/handlers/client-handlers.ts
@@ -5,25 +5,11 @@ import {
 	IdParamSchema,
 	PaginationRequestSchema,
 } from "@repo/data-ops/client";
-import type { Context } from "hono";
 import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { authMiddleware } from "../middleware/auth";
 import * as clientService from "../services/client-service";
-import type { Result } from "../types/result";
-
-function resultToResponse<T>(
-	c: Context,
-	result: Result<T>,
-	successStatus: ContentfulStatusCode = 200,
-) {
-	if (!result.ok)
-		return c.json(
-			{ error: result.error.message, code: result.error.code },
-			result.error.status as ContentfulStatusCode,
-		);
-	return c.json(result.data, successStatus);
-}
+import { resultToResponse } from "../utils/response";
 
 const clients = new Hono<{ Bindings: Env }>();
 

--- a/apps/data-service/src/hono/handlers/project-handlers.ts
+++ b/apps/data-service/src/hono/handlers/project-handlers.ts
@@ -1,25 +1,10 @@
 import { zValidator } from "@hono/zod-validator";
 import { PaginationRequestSchema } from "@repo/data-ops/client";
 import { ProjectCreateRequestSchema, SlugParamSchema } from "@repo/data-ops/project";
-import type { Context } from "hono";
 import { Hono } from "hono";
-import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { authMiddleware } from "../middleware/auth";
 import * as projectService from "../services/project-service";
-import type { Result } from "../types/result";
-
-function resultToResponse<T>(
-	c: Context,
-	result: Result<T>,
-	successStatus: ContentfulStatusCode = 200,
-) {
-	if (!result.ok)
-		return c.json(
-			{ error: result.error.message, code: result.error.code },
-			result.error.status as ContentfulStatusCode,
-		);
-	return c.json(result.data, successStatus);
-}
+import { resultToResponse } from "../utils/response";
 
 const projects = new Hono<{ Bindings: Env }>();
 

--- a/apps/data-service/src/hono/services/chat-service.test.ts
+++ b/apps/data-service/src/hono/services/chat-service.test.ts
@@ -1,0 +1,56 @@
+import type { Message } from "@repo/data-ops/project";
+import { buildClaudeMessages } from "./chat-service";
+
+function makeMessage(
+	overrides: Partial<Message> & { role: Message["role"]; content: string },
+): Message {
+	return {
+		id: crypto.randomUUID(),
+		projectId: crypto.randomUUID(),
+		phase: null,
+		createdAt: new Date(),
+		...overrides,
+	};
+}
+
+describe("buildClaudeMessages", () => {
+	it("builds messages array from empty history plus new content", () => {
+		const result = buildClaudeMessages([], "Hello");
+		expect(result).toEqual([{ role: "user", content: "Hello" }]);
+	});
+
+	it("includes full conversation history before new message", () => {
+		const history: Message[] = [
+			makeMessage({ role: "user", content: "First" }),
+			makeMessage({ role: "assistant", content: "Response" }),
+		];
+
+		const result = buildClaudeMessages(history, "Second");
+		expect(result).toEqual([
+			{ role: "user", content: "First" },
+			{ role: "assistant", content: "Response" },
+			{ role: "user", content: "Second" },
+		]);
+	});
+
+	it("maps system role messages to user role for Claude API", () => {
+		const history: Message[] = [makeMessage({ role: "system", content: "System note" })];
+
+		const result = buildClaudeMessages(history, "Hello");
+		expect(result[0]?.role).toBe("user");
+		expect(result[0]?.content).toBe("System note");
+	});
+
+	it("preserves message order from history", () => {
+		const history: Message[] = [
+			makeMessage({ role: "user", content: "A" }),
+			makeMessage({ role: "assistant", content: "B" }),
+			makeMessage({ role: "user", content: "C" }),
+			makeMessage({ role: "assistant", content: "D" }),
+		];
+
+		const result = buildClaudeMessages(history, "E");
+		expect(result).toHaveLength(5);
+		expect(result.map((m) => m.content)).toEqual(["A", "B", "C", "D", "E"]);
+	});
+});

--- a/apps/data-service/src/hono/services/chat-service.ts
+++ b/apps/data-service/src/hono/services/chat-service.ts
@@ -1,0 +1,99 @@
+import Anthropic from "@anthropic-ai/sdk";
+import {
+	createMessage as createMessageQuery,
+	getMessagesByProjectId,
+	getProjectBySlug as getProjectBySlugQuery,
+	type Message,
+	type MessageCreateInput,
+} from "@repo/data-ops/project";
+import type { Result } from "../types/result";
+
+const DISCOVERY_SYSTEM_PROMPT = `You are an expert discovery interviewer for a software development agency. Your job is to understand the client's project requirements through a structured conversation.
+
+Guide the conversation through these areas:
+1. Project overview - What are they building and why?
+2. Target users - Who will use this and what problems does it solve?
+3. Core features - What are the must-have capabilities?
+4. Technical constraints - Any existing systems, platforms, or tech requirements?
+5. Timeline and budget - What are the expectations?
+
+Be conversational, ask one question at a time, and dig deeper when answers are vague. Summarize what you've learned periodically to confirm understanding.`;
+
+interface SendMessageResult {
+	userMessage: Message;
+	assistantMessage: Message;
+}
+
+export async function getMessageHistory(slug: string): Promise<Result<Message[]>> {
+	const project = await getProjectBySlugQuery(slug);
+	if (!project) {
+		return {
+			ok: false,
+			error: { code: "NOT_FOUND", message: "Project not found", status: 404 },
+		};
+	}
+	const messages = await getMessagesByProjectId(project.id);
+	return { ok: true, data: messages };
+}
+
+export function buildClaudeMessages(
+	history: Message[],
+	newContent: string,
+): Anthropic.MessageParam[] {
+	const params: Anthropic.MessageParam[] = history.map((m) => ({
+		role: m.role === "assistant" ? "assistant" : "user",
+		content: m.content,
+	}));
+	params.push({ role: "user", content: newContent });
+	return params;
+}
+
+export async function sendMessage(
+	slug: string,
+	data: MessageCreateInput,
+	apiKey: string,
+): Promise<Result<SendMessageResult>> {
+	const project = await getProjectBySlugQuery(slug);
+	if (!project) {
+		return {
+			ok: false,
+			error: { code: "NOT_FOUND", message: "Project not found", status: 404 },
+		};
+	}
+
+	const history = await getMessagesByProjectId(project.id);
+
+	const userMessage = await createMessageQuery({
+		projectId: project.id,
+		role: "user",
+		content: data.content,
+	});
+
+	const claudeMessages = buildClaudeMessages(history, data.content);
+
+	const client = new Anthropic({ apiKey });
+	let assistantContent: string;
+	try {
+		const response = await client.messages.create({
+			model: "claude-sonnet-4-20250514",
+			max_tokens: 1024,
+			system: DISCOVERY_SYSTEM_PROMPT,
+			messages: claudeMessages,
+		});
+		const textBlock = response.content.find((b) => b.type === "text");
+		assistantContent = textBlock?.text ?? "";
+	} catch {
+		return {
+			ok: false,
+			error: { code: "AI_ERROR", message: "Failed to get AI response", status: 502 },
+		};
+	}
+
+	const assistantMessage = await createMessageQuery({
+		projectId: project.id,
+		role: "assistant",
+		content: assistantContent,
+	});
+
+	return { ok: true, data: { userMessage, assistantMessage } };
+}

--- a/apps/data-service/src/hono/utils/response.ts
+++ b/apps/data-service/src/hono/utils/response.ts
@@ -1,0 +1,16 @@
+import type { Context } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import type { Result } from "../types/result";
+
+export function resultToResponse<T>(
+	c: Context,
+	result: Result<T>,
+	successStatus: ContentfulStatusCode = 200,
+) {
+	if (!result.ok)
+		return c.json(
+			{ error: result.error.message, code: result.error.code },
+			result.error.status as ContentfulStatusCode,
+		);
+	return c.json(result.data, successStatus);
+}

--- a/apps/user-application/src/components/chat/chat-input.tsx
+++ b/apps/user-application/src/components/chat/chat-input.tsx
@@ -1,0 +1,54 @@
+import { useRef, useState } from "react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+
+interface ChatInputProps {
+	onSend: (content: string) => void;
+	isPending: boolean;
+	error?: string;
+}
+
+export function ChatInput({ onSend, isPending, error }: ChatInputProps) {
+	const [content, setContent] = useState("");
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+		const trimmed = content.trim();
+		if (!trimmed || isPending) return;
+		onSend(trimmed);
+		setContent("");
+	};
+
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+		if (e.key === "Enter" && !e.shiftKey) {
+			e.preventDefault();
+			handleSubmit(e);
+		}
+	};
+
+	return (
+		<div className="border-t bg-background px-4 py-3 shrink-0">
+			{error && (
+				<Alert variant="destructive" className="mb-3">
+					<AlertDescription>{error}</AlertDescription>
+				</Alert>
+			)}
+			<form onSubmit={handleSubmit} className="max-w-3xl mx-auto flex gap-2">
+				<textarea
+					ref={textareaRef}
+					value={content}
+					onChange={(e) => setContent(e.target.value)}
+					onKeyDown={handleKeyDown}
+					placeholder="Type your message..."
+					disabled={isPending}
+					rows={1}
+					className="flex-1 resize-none rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+				/>
+				<Button type="submit" disabled={!content.trim() || isPending}>
+					{isPending ? "Sending..." : "Send"}
+				</Button>
+			</form>
+		</div>
+	);
+}

--- a/apps/user-application/src/components/chat/chat-message-list.tsx
+++ b/apps/user-application/src/components/chat/chat-message-list.tsx
@@ -1,0 +1,60 @@
+import type { Message } from "@repo/data-ops/project";
+import { useEffect, useRef } from "react";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { ChatMessage } from "./chat-message";
+
+interface ChatMessageListProps {
+	messages: Message[];
+	isLoading: boolean;
+	isPending: boolean;
+}
+
+export function ChatMessageList({ messages, isLoading, isPending }: ChatMessageListProps) {
+	const bottomRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+	}, []);
+
+	if (isLoading) {
+		return (
+			<div className="flex-1 flex items-center justify-center">
+				<div className="flex items-center gap-2 text-muted-foreground">
+					<div className="animate-spin h-4 w-4 border-2 border-primary border-t-transparent rounded-full" />
+					<span>Loading conversation...</span>
+				</div>
+			</div>
+		);
+	}
+
+	if (messages.length === 0 && !isPending) {
+		return (
+			<div className="flex-1 flex items-center justify-center p-8">
+				<div className="text-center max-w-md">
+					<p className="text-lg font-medium text-foreground">Welcome!</p>
+					<p className="text-muted-foreground mt-1">
+						Send a message to start the discovery interview. We'll ask questions to understand your
+						project requirements.
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<ScrollArea className="flex-1">
+			<div className="max-w-3xl mx-auto px-4 py-6 space-y-4">
+				{messages.map((message) => (
+					<ChatMessage key={message.id} message={message} />
+				))}
+				{isPending && (
+					<div className="flex items-center gap-2 text-muted-foreground py-2">
+						<div className="animate-spin h-3 w-3 border-2 border-primary border-t-transparent rounded-full" />
+						<span className="text-sm">Thinking...</span>
+					</div>
+				)}
+				<div ref={bottomRef} />
+			</div>
+		</ScrollArea>
+	);
+}

--- a/apps/user-application/src/components/chat/chat-message.tsx
+++ b/apps/user-application/src/components/chat/chat-message.tsx
@@ -1,0 +1,23 @@
+import type { Message } from "@repo/data-ops/project";
+import { cn } from "@/lib/utils";
+
+interface ChatMessageProps {
+	message: Message;
+}
+
+export function ChatMessage({ message }: ChatMessageProps) {
+	const isAssistant = message.role === "assistant";
+
+	return (
+		<div className={cn("flex", isAssistant ? "justify-start" : "justify-end")}>
+			<div
+				className={cn(
+					"max-w-[80%] rounded-lg px-4 py-2.5",
+					isAssistant ? "bg-muted text-foreground" : "bg-primary text-primary-foreground",
+				)}
+			>
+				<p className="text-sm whitespace-pre-wrap">{message.content}</p>
+			</div>
+		</div>
+	);
+}

--- a/apps/user-application/src/core/functions/chat/binding.ts
+++ b/apps/user-application/src/core/functions/chat/binding.ts
@@ -1,0 +1,62 @@
+import { env } from "cloudflare:workers";
+import { type Message, MessageCreateRequestSchema, MessageSchema } from "@repo/data-ops/project";
+import { createServerFn } from "@tanstack/react-start";
+import { z } from "zod";
+import { AppError } from "@/core/errors";
+
+interface ErrorBody {
+	message?: string;
+	code?: string;
+}
+
+const makeChatRequest = async (path: string, options: RequestInit = {}) => {
+	return env.DATA_SERVICE.fetch(
+		new Request(`https://data-service${path}`, {
+			headers: {
+				"Content-Type": "application/json",
+				...options.headers,
+			},
+			...options,
+		}),
+	);
+};
+
+async function throwOnError(response: Response, fallbackMessage: string): Promise<never> {
+	const body = (await response.json().catch(() => ({}))) as ErrorBody;
+	throw new AppError(body.message || fallbackMessage, body.code || "API_ERROR", response.status);
+}
+
+const SlugInput = z.object({ slug: z.string().min(1) });
+
+export const getChatMessages = createServerFn()
+	.inputValidator((data: z.infer<typeof SlugInput>) => SlugInput.parse(data))
+	.handler(async (ctx): Promise<Message[]> => {
+		const response = await makeChatRequest(`/chat/${ctx.data.slug}/messages`);
+		if (!response.ok) await throwOnError(response, "Failed to fetch messages");
+		return z.array(MessageSchema).parse(await response.json());
+	});
+
+const SendMessageInput = z.object({
+	slug: z.string().min(1),
+	content: MessageCreateRequestSchema.shape.content,
+});
+
+interface SendMessageResponse {
+	userMessage: Message;
+	assistantMessage: Message;
+}
+
+export const sendChatMessage = createServerFn({ method: "POST" })
+	.inputValidator((data: unknown) => SendMessageInput.parse(data))
+	.handler(async (ctx): Promise<SendMessageResponse> => {
+		const response = await makeChatRequest(`/chat/${ctx.data.slug}/messages`, {
+			method: "POST",
+			body: JSON.stringify({ content: ctx.data.content }),
+		});
+		if (!response.ok) await throwOnError(response, "Failed to send message");
+		const body = (await response.json()) as SendMessageResponse;
+		return {
+			userMessage: MessageSchema.parse(body.userMessage),
+			assistantMessage: MessageSchema.parse(body.assistantMessage),
+		};
+	});

--- a/apps/user-application/src/lib/query-keys.ts
+++ b/apps/user-application/src/lib/query-keys.ts
@@ -1,10 +1,25 @@
 import type { Client, ClientListResponse } from "@repo/data-ops/client";
+import type { Message } from "@repo/data-ops/project";
 import { queryOptions } from "@tanstack/react-query";
+import { getChatMessages } from "@/core/functions/chat/binding";
 import { getClientBinding, getClientsBinding } from "@/core/functions/clients/binding";
 import { getClientDirect, getClientsDirect } from "@/core/functions/clients/direct";
 import { fetchClient, fetchClients } from "./api-client";
 
 type PaginationParams = { limit: number; offset: number };
+
+export const chatKeys = {
+	all: ["chat"] as const,
+	messages: (slug: string) => [...chatKeys.all, "messages", slug] as const,
+};
+
+export const chatQueries = {
+	messages: (slug: string) =>
+		queryOptions<Message[]>({
+			queryKey: chatKeys.messages(slug),
+			queryFn: () => getChatMessages({ data: { slug } }),
+		}),
+};
 
 interface EntityKeys {
 	detail: (id: string) => readonly unknown[];

--- a/apps/user-application/src/routeTree.gen.ts
+++ b/apps/user-application/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as SignupRouteImport } from './routes/signup'
 import { Route as SigninRouteImport } from './routes/signin'
 import { Route as AuthRouteRouteImport } from './routes/_auth/route'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as PSlugRouteImport } from './routes/p/$slug'
 import { Route as ApiHealthRouteImport } from './routes/api/health'
 import { Route as AuthDashboardRouteRouteImport } from './routes/_auth/dashboard/route'
 import { Route as AuthDashboardIndexRouteImport } from './routes/_auth/dashboard/index'
@@ -57,6 +58,11 @@ const AuthRouteRoute = AuthRouteRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PSlugRoute = PSlugRouteImport.update({
+  id: '/p/$slug',
+  path: '/p/$slug',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiHealthRoute = ApiHealthRouteImport.update({
@@ -208,6 +214,7 @@ export interface FileRoutesByFullPath {
   '/signup': typeof SignupRoute
   '/dashboard': typeof AuthDashboardRouteRouteWithChildren
   '/api/health': typeof ApiHealthRoute
+  '/p/$slug': typeof PSlugRoute
   '/dashboard/api': typeof AuthDashboardApiRouteRouteWithChildren
   '/dashboard/binding': typeof AuthDashboardBindingRouteRouteWithChildren
   '/dashboard/direct': typeof AuthDashboardDirectRouteRouteWithChildren
@@ -238,6 +245,7 @@ export interface FileRoutesByTo {
   '/signin': typeof SigninRoute
   '/signup': typeof SignupRoute
   '/api/health': typeof ApiHealthRoute
+  '/p/$slug': typeof PSlugRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/app': typeof AuthAppIndexRoute
   '/dashboard': typeof AuthDashboardIndexRoute
@@ -268,6 +276,7 @@ export interface FileRoutesById {
   '/signup': typeof SignupRoute
   '/_auth/dashboard': typeof AuthDashboardRouteRouteWithChildren
   '/api/health': typeof ApiHealthRoute
+  '/p/$slug': typeof PSlugRoute
   '/_auth/dashboard/api': typeof AuthDashboardApiRouteRouteWithChildren
   '/_auth/dashboard/binding': typeof AuthDashboardBindingRouteRouteWithChildren
   '/_auth/dashboard/direct': typeof AuthDashboardDirectRouteRouteWithChildren
@@ -301,6 +310,7 @@ export interface FileRouteTypes {
     | '/signup'
     | '/dashboard'
     | '/api/health'
+    | '/p/$slug'
     | '/dashboard/api'
     | '/dashboard/binding'
     | '/dashboard/direct'
@@ -331,6 +341,7 @@ export interface FileRouteTypes {
     | '/signin'
     | '/signup'
     | '/api/health'
+    | '/p/$slug'
     | '/api/auth/$'
     | '/app'
     | '/dashboard'
@@ -360,6 +371,7 @@ export interface FileRouteTypes {
     | '/signup'
     | '/_auth/dashboard'
     | '/api/health'
+    | '/p/$slug'
     | '/_auth/dashboard/api'
     | '/_auth/dashboard/binding'
     | '/_auth/dashboard/direct'
@@ -392,6 +404,7 @@ export interface RootRouteChildren {
   SigninRoute: typeof SigninRoute
   SignupRoute: typeof SignupRoute
   ApiHealthRoute: typeof ApiHealthRoute
+  PSlugRoute: typeof PSlugRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
 }
 
@@ -423,6 +436,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/p/$slug': {
+      id: '/p/$slug'
+      path: '/p/$slug'
+      fullPath: '/p/$slug'
+      preLoaderRoute: typeof PSlugRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/health': {
@@ -718,6 +738,7 @@ const rootRouteChildren: RootRouteChildren = {
   SigninRoute: SigninRoute,
   SignupRoute: SignupRoute,
   ApiHealthRoute: ApiHealthRoute,
+  PSlugRoute: PSlugRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/user-application/src/routes/p/$slug.tsx
+++ b/apps/user-application/src/routes/p/$slug.tsx
@@ -1,0 +1,50 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { ChatInput } from "@/components/chat/chat-input";
+import { ChatMessageList } from "@/components/chat/chat-message-list";
+import { sendChatMessage } from "@/core/functions/chat/binding";
+import { chatKeys, chatQueries } from "@/lib/query-keys";
+
+export const Route = createFileRoute("/p/$slug")({
+	loader: async ({ context, params }) => {
+		await context.queryClient.ensureQueryData(chatQueries.messages(params.slug));
+	},
+	component: ChatPage,
+});
+
+function ChatPage() {
+	const { slug } = Route.useParams();
+	const queryClient = useQueryClient();
+
+	const { data: messages = [], isLoading } = useQuery(chatQueries.messages(slug));
+
+	const mutation = useMutation({
+		mutationFn: (content: string) => sendChatMessage({ data: { slug, content } }),
+		onSuccess: (result) => {
+			queryClient.setQueryData(chatKeys.messages(slug), (old: typeof messages) => [
+				...(old ?? []),
+				result.userMessage,
+				result.assistantMessage,
+			]);
+		},
+	});
+
+	return (
+		<div className="flex flex-col h-screen bg-background">
+			<header className="border-b px-4 py-3 shrink-0">
+				<h1 className="text-lg font-semibold text-foreground">Project Interview</h1>
+				<p className="text-sm text-muted-foreground">
+					Tell us about your project and we'll help define the requirements.
+				</p>
+			</header>
+
+			<ChatMessageList messages={messages} isLoading={isLoading} isPending={mutation.isPending} />
+
+			<ChatInput
+				onSend={(content) => mutation.mutate(content)}
+				isPending={mutation.isPending}
+				error={mutation.error?.message}
+			/>
+		</div>
+	);
+}

--- a/packages/data-ops/src/project/index.ts
+++ b/packages/data-ops/src/project/index.ts
@@ -1,6 +1,14 @@
-export { createProject, deleteProject, getProjectBySlug, getProjects } from "./queries";
+export {
+	createMessage,
+	createProject,
+	deleteProject,
+	getMessagesByProjectId,
+	getProjectBySlug,
+	getProjects,
+} from "./queries";
 export type {
 	Message,
+	MessageCreateInput,
 	Project,
 	ProjectCreateInput,
 	ProjectListResponse,
@@ -8,6 +16,7 @@ export type {
 	Task,
 } from "./schema";
 export {
+	MessageCreateRequestSchema,
 	MessageSchema,
 	ProjectCreateRequestSchema,
 	ProjectListResponseSchema,

--- a/packages/data-ops/src/project/queries.test.ts
+++ b/packages/data-ops/src/project/queries.test.ts
@@ -1,6 +1,12 @@
 import { eq } from "drizzle-orm";
 import { getDb, initDatabase } from "@/database/setup";
-import { createProject, getProjectBySlug, getProjects } from "./queries";
+import {
+	createMessage,
+	createProject,
+	getMessagesByProjectId,
+	getProjectBySlug,
+	getProjects,
+} from "./queries";
 import { projects } from "./table";
 
 beforeAll(() => {
@@ -66,5 +72,60 @@ describe("getProjects", () => {
 		const db = getDb();
 		await db.delete(projects).where(eq(projects.id, p1.id));
 		await db.delete(projects).where(eq(projects.id, p2.id));
+	});
+});
+
+describe("createMessage", () => {
+	it("persists a message and returns it with generated id and timestamps", async () => {
+		const project = await createProject({ name: "__test_project__" });
+
+		const message = await createMessage({
+			projectId: project.id,
+			role: "user",
+			content: "Hello, I need help",
+		});
+
+		expect(message.id).toBeDefined();
+		expect(message.projectId).toBe(project.id);
+		expect(message.role).toBe("user");
+		expect(message.content).toBe("Hello, I need help");
+		expect(message.createdAt).toBeInstanceOf(Date);
+
+		// cleanup via cascade
+		const db = getDb();
+		await db.delete(projects).where(eq(projects.id, project.id));
+	});
+});
+
+describe("getMessagesByProjectId", () => {
+	it("returns messages ordered by createdAt ascending", async () => {
+		const project = await createProject({ name: "__test_project__" });
+
+		await createMessage({ projectId: project.id, role: "user", content: "First" });
+		await createMessage({ projectId: project.id, role: "assistant", content: "Second" });
+		await createMessage({ projectId: project.id, role: "user", content: "Third" });
+
+		const result = await getMessagesByProjectId(project.id);
+		expect(result).toHaveLength(3);
+		expect(result[0]?.content).toBe("First");
+		expect(result[1]?.content).toBe("Second");
+		expect(result[2]?.content).toBe("Third");
+		expect(result[0]?.role).toBe("user");
+		expect(result[1]?.role).toBe("assistant");
+
+		// cleanup via cascade
+		const db = getDb();
+		await db.delete(projects).where(eq(projects.id, project.id));
+	});
+
+	it("returns empty array for project with no messages", async () => {
+		const project = await createProject({ name: "__test_project__" });
+
+		const result = await getMessagesByProjectId(project.id);
+		expect(result).toEqual([]);
+
+		// cleanup
+		const db = getDb();
+		await db.delete(projects).where(eq(projects.id, project.id));
 	});
 });

--- a/packages/data-ops/src/project/queries.ts
+++ b/packages/data-ops/src/project/queries.ts
@@ -1,9 +1,42 @@
-import { count, eq } from "drizzle-orm";
+import { asc, count, eq } from "drizzle-orm";
 import type { PaginationRequest } from "@/client/schema";
 import { getDb } from "@/database/setup";
-import type { Project, ProjectCreateInput, ProjectListResponse } from "./schema";
+import type {
+	Message,
+	MessageCreateInput,
+	Project,
+	ProjectCreateInput,
+	ProjectListResponse,
+} from "./schema";
 import { generateSlug } from "./slug";
-import { projects } from "./table";
+import { messages, projects } from "./table";
+
+export async function createMessage(
+	data: MessageCreateInput & { projectId: string; role: Message["role"] },
+): Promise<Message> {
+	const db = getDb();
+	const [message] = await db
+		.insert(messages)
+		.values({
+			projectId: data.projectId,
+			role: data.role,
+			content: data.content,
+		})
+		.returning();
+	if (!message) {
+		throw new Error("Failed to create message");
+	}
+	return message;
+}
+
+export async function getMessagesByProjectId(projectId: string): Promise<Message[]> {
+	const db = getDb();
+	return db
+		.select()
+		.from(messages)
+		.where(eq(messages.projectId, projectId))
+		.orderBy(asc(messages.createdAt));
+}
 
 export async function createProject(data: ProjectCreateInput): Promise<Project> {
 	const db = getDb();

--- a/packages/data-ops/src/project/schema.test.ts
+++ b/packages/data-ops/src/project/schema.test.ts
@@ -1,4 +1,23 @@
-import { ProjectCreateRequestSchema, SlugParamSchema } from "./schema";
+import { MessageCreateRequestSchema, ProjectCreateRequestSchema, SlugParamSchema } from "./schema";
+
+describe("MessageCreateRequestSchema", () => {
+	it("accepts valid content", () => {
+		const result = MessageCreateRequestSchema.safeParse({
+			content: "Hello, I need help with my project",
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects empty content", () => {
+		const result = MessageCreateRequestSchema.safeParse({ content: "" });
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects missing content", () => {
+		const result = MessageCreateRequestSchema.safeParse({});
+		expect(result.success).toBe(false);
+	});
+});
 
 describe("ProjectCreateRequestSchema", () => {
 	it("accepts valid name", () => {

--- a/packages/data-ops/src/project/schema.ts
+++ b/packages/data-ops/src/project/schema.ts
@@ -74,6 +74,10 @@ export const ProjectListResponseSchema = z.object({
 	}),
 });
 
+export const MessageCreateRequestSchema = z.object({
+	content: z.string().min(1, "Content is required"),
+});
+
 // ============================================
 // Types
 // ============================================
@@ -83,4 +87,5 @@ export type Message = z.infer<typeof MessageSchema>;
 export type Spec = z.infer<typeof SpecSchema>;
 export type Task = z.infer<typeof TaskSchema>;
 export type ProjectCreateInput = z.infer<typeof ProjectCreateRequestSchema>;
+export type MessageCreateInput = z.infer<typeof MessageCreateRequestSchema>;
 export type ProjectListResponse = z.infer<typeof ProjectListResponseSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
 
   apps/data-service:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.80.0
+        version: 0.80.0(zod@4.3.6)
       '@hono/zod-validator':
         specifier: ^0.7.6
         version: 0.7.6(hono@4.12.8)(zod@4.3.6)
@@ -232,6 +235,15 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
+  '@anthropic-ai/sdk@0.80.0':
+    resolution: {integrity: sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
@@ -321,6 +333,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
@@ -3958,6 +3974,10 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-with-bigint@3.5.7:
     resolution: {integrity: sha512-7ei3MdAI5+fJPVnKlW77TKNKwQ5ppSzWvhPuSuINT/GYW9ZOC1eRKOuhV9yHG5aEsUPj9BBx5JIekkmoLHxZOw==}
 
@@ -5074,6 +5094,9 @@ packages:
     resolution: {integrity: sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==}
     engines: {node: '>= 0.4'}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   tsc-alias@1.8.16:
     resolution: {integrity: sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==}
     engines: {node: '>=16.20.2'}
@@ -5509,6 +5532,12 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
 
+  '@anthropic-ai/sdk@0.80.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
+
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
@@ -5622,6 +5651,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/runtime@7.29.2': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -9061,6 +9092,11 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
   json-with-bigint@3.5.7: {}
 
   json5@2.2.3: {}
@@ -10197,6 +10233,8 @@ snapshots:
       punycode: 2.3.1
 
   traverse@0.6.8: {}
+
+  ts-algebra@2.0.0: {}
 
   tsc-alias@1.8.16:
     dependencies:


### PR DESCRIPTION
## Summary

- Add chat API endpoints (`GET/POST /chat/:slug/messages`) with Claude API integration for AI-powered discovery interviews
- Create message persistence layer (queries, Zod schemas) in data-ops
- Build frontend chat UI at `/p/:slug` with message history, input form, and loading/pending states
- Extract shared `resultToResponse` utility from duplicated handler code
- 55 tests passing (unit + integration against real Neon Postgres, Claude SDK mocked)

Closes #3

## Test plan

- [ ] Verify `pnpm run types` passes
- [ ] Verify `pnpm --filter @repo/data-ops test -- --run` passes (38 tests)
- [ ] Verify `pnpm --filter data-service test -- --run` passes (17 tests)
- [ ] Add `ANTHROPIC_API_KEY` to data-service `.dev.vars`
- [ ] Start both dev servers and create a project via `POST /projects`
- [ ] Open `/p/:slug` in browser — confirm chat loads, messages send, AI responds
- [ ] Close and reopen the page — confirm conversation history resumes
- [ ] e2e tests to follow after implementation review

🤖 Generated with [Claude Code](https://claude.com/claude-code)